### PR TITLE
feat: optimize Dockerfile to make image build faster

### DIFF
--- a/samples/go-contract/Dockerfile.optimized
+++ b/samples/go-contract/Dockerfile.optimized
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+
+ARG GO_VER=1.17.5
+ARG ALPINE_VER=3.14
+
+FROM golang:${GO_VER}-alpine${ALPINE_VER} as build
+
+# Use aliyun apk repository to make image build faster
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
+
+RUN apk add --no-cache \
+	bash \
+	binutils-gold \
+  dumb-init \
+	gcc \
+	git \
+	make \
+	musl-dev
+
+ADD . $GOPATH/src/github.com/hyperledger-labs/fabric-builder-k8s/samples/go-contract
+WORKDIR $GOPATH/src/github.com/hyperledger-labs/fabric-builder-k8s/samples/go-contract
+
+ENV GOPROXY=https://goproxy.cn,direct
+RUN go install ./...
+
+FROM golang:${GO_VER}-alpine${ALPINE_VER}
+
+LABEL org.opencontainers.image.title "Sample Go Contract"
+LABEL org.opencontainers.image.description "Sample Hyperledger Fabric Go contract for Kubernetes chaincode builder"
+LABEL org.opencontainers.image.source "https://github.com/hyperledger-labs/fabric-builder-k8s/samples/go-contract"
+
+
+
+COPY --from=build /usr/bin/dumb-init /usr/bin/dumb-init
+COPY --from=build /go/bin/go-contract /usr/bin/go-contract
+
+WORKDIR /var/hyperledger/go-contract
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["sh", "-c", "exec /usr/bin/go-contract -peer.address=$CORE_PEER_ADDRESS"]

--- a/samples/java-contract/Dockerfile.optimized
+++ b/samples/java-contract/Dockerfile.optimized
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+
+ARG JAVA_VER=11
+
+FROM eclipse-temurin:${JAVA_VER}-jdk-alpine as build
+
+# Use aliyun apk repository to make image build faster
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
+
+RUN apk add --no-cache \
+  dumb-init
+
+WORKDIR /usr/src/app
+
+COPY ./gradle/wrapper/ ./gradle/wrapper/
+COPY gradlew .
+RUN ./gradlew --version
+
+COPY . .
+
+RUN ./gradlew jar
+
+FROM eclipse-temurin:${JAVA_VER}-jre-alpine
+
+LABEL org.opencontainers.image.title "Sample Java Contract"
+LABEL org.opencontainers.image.description "Sample Hyperledger Fabric Java contract for Kubernetes chaincode builder"
+LABEL org.opencontainers.image.source "https://github.com/hyperledger-labs/fabric-builder-k8s/samples/java-contract"
+
+WORKDIR /var/hyperledger/java-contract
+
+COPY --from=build /usr/bin/dumb-init /usr/bin/dumb-init
+COPY --from=build /usr/src/app/build/libs/sample-contract.jar ./sample-contract.jar
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["sh", "-c", "exec /opt/java/openjdk/bin/java -jar ./sample-contract.jar --peer.address=$CORE_PEER_ADDRESS"]

--- a/samples/node-contract/Dockerfile.optimized
+++ b/samples/node-contract/Dockerfile.optimized
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+
+ARG NODE_VER=16
+ARG ALPINE_VER=3.14
+
+FROM node:${NODE_VER}-alpine${ALPINE_VER} as build
+
+# Use aliyun apk repository to make image build faster
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
+
+RUN apk add --no-cache \
+  dumb-init
+
+FROM node:${NODE_VER}-alpine${ALPINE_VER}
+
+LABEL org.opencontainers.image.title "Sample Node Contract"
+LABEL org.opencontainers.image.description "Sample Hyperledger Fabric Node contract for Kubernetes chaincode builder"
+LABEL org.opencontainers.image.source "https://github.com/hyperledger-labs/fabric-builder-k8s/samples/node-contract"
+
+COPY --from=build /usr/bin/dumb-init /usr/bin/dumb-init
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm ci
+
+COPY . .
+
+RUN npm run compile
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["sh", "-c", "exec npm start -- --peer.address $CORE_PEER_ADDRESS"]


### PR DESCRIPTION
Optimzations in Chaincode image build 
1. change apk repositories to aliyun
2. use GOPROXY to make go build faster